### PR TITLE
Add LLM prompt integration

### DIFF
--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -354,6 +354,8 @@ public:
 
     virtual bool SaveAndRunBuffer(const std::string& name, const std::string& code);
 
+    virtual bool ProcessPrompt(const std::string& prompt);
+
     virtual const APISettings& GetSettings() const;
     virtual void SetSettings(const APISettings& settings);
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -1035,6 +1035,19 @@ bool SonicPiAPI::SaveAndRunBuffer(const std::string& name, const std::string& te
     return true;
 }
 
+bool SonicPiAPI::ProcessPrompt(const std::string& prompt)
+{
+    Message msg("/process-prompt");
+    msg.pushInt32(m_token);
+    msg.pushStr(prompt);
+    bool res = SendOSC(msg);
+    if (!res)
+    {
+        return false;
+    }
+    return true;
+}
+
 const APISettings& SonicPiAPI::GetSettings() const
 {
     return m_settings;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -1857,6 +1857,15 @@ void MainWindow::runCode()
     statusBar()->showMessage(tr("Running Code..."), 1000);
 }
 
+void MainWindow::sendPrompt()
+{
+    QString text = llm_prompt->text();
+    if (!text.isEmpty())
+    {
+        m_spAPI->ProcessPrompt(text.toStdString());
+    }
+}
+
 void MainWindow::zoomCurrentWorkspaceIn()
 {
     statusBar()->showMessage(tr("Zooming In..."), 2000);
@@ -3453,6 +3462,11 @@ void MainWindow::createToolBar()
     toolBar->addAction(recAct);
     toolBar->addAction(saveAsAct);
     toolBar->addAction(loadFileAct);
+
+    llm_prompt = new QLineEdit();
+    llm_prompt->setPlaceholderText(tr("LLM Prompt"));
+    toolBar->addWidget(llm_prompt);
+    connect(llm_prompt, SIGNAL(returnPressed()), this, SLOT(sendPrompt()));
 
     toolBar->addWidget(spacer);
 

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -151,6 +151,7 @@ private slots:
     QString asciiArtLogo();
     void printAsciiArtLogo();
     void runCode();
+    void sendPrompt();
     void update_check_updates();
     void mixerSettingsChanged();
     void check_for_updates_now();
@@ -414,6 +415,8 @@ private:
     bool is_recording;
     bool show_rec_icon_a;
     QTimer* rec_flash_timer;
+
+    QLineEdit* llm_prompt;
 
     QSplashScreen* splash;
 

--- a/app/server/ruby/bin/spider-server.rb
+++ b/app/server/ruby/bin/spider-server.rb
@@ -308,6 +308,17 @@ register_api = lambda do |server|
     end
   end
 
+  server.add_method("/process-prompt") do |args|
+    incoming_token = args[0]
+    if incoming_token == token
+      prompt = args[1].force_encoding("utf-8")
+      sp.__process_prompt(prompt)
+    else
+      STDOUT.puts "Invalid token: #{incoming_token} - ignoring /process-prompt API call"
+      STDOUT.flush
+    end
+  end
+
   server.add_method("/save-buffer") do |args|
     incoming_token = args[0]
     if incoming_token == token

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -27,9 +27,10 @@ require_relative "sthread"
 require_relative "version"
 require_relative "config/settings"
 require_relative "preparser"
-require_relative "event_history"
-require_relative "thread_id"
-require_relative "tau_api"
+    require_relative "event_history"
+    require_relative "thread_id"
+    require_relative "tau_api"
+    require 'json'
 
 #require_relative "oscevent"
 #require_relative "stream"
@@ -873,6 +874,28 @@ module SonicPi
 
     def __save_buffer(id, content)
       @save_queue << [id, content]
+    end
+
+    def __generate_code_from_prompt(prompt)
+      uri = URI.parse('http://127.0.0.1:11434/api/generate')
+      req = Net::HTTP::Post.new(uri)
+      req['Content-Type'] = 'application/json'
+      req.body = MultiJson.dump({model: 'sonic-pi', prompt: prompt, stream: false})
+      res = Net::HTTP.start(uri.hostname, uri.port) {|http| http.request(req)}
+      if res.is_a?(Net::HTTPSuccess)
+        data = MultiJson.load(res.body)
+        data['response'] || ''
+      else
+        ''
+      end
+    rescue StandardError => e
+      __info "LLM request failed: #{e.message}"
+      ''
+    end
+
+    def __process_prompt(prompt)
+      code = __generate_code_from_prompt(prompt)
+      __spider_eval(code, {workspace: 'prompt'}) unless code.empty?
     end
 
     def __disable_update_checker


### PR DESCRIPTION
## Summary
- add JSON dependency and new LLM helper methods to Ruby runtime
- expose new `/process-prompt` OSC endpoint in spider-server
- support prompt sending in SonicPiAPI
- add GUI text entry for LLM prompts and call `ProcessPrompt`

## Testing
- `rake test`