### PR TITLE
Add LLM prompt integration

### DIFF
--- a/app/api/include/api/sonicpi_api.h
+++ b/app/api/include/api/sonicpi_api.h
@@ -354,6 +354,9 @@ public:
 
     virtual bool SaveAndRunBuffer(const std::string& name, const std::string& code);
 
+    virtual bool ProcessPrompt(const std::string& prompt);
+    virtual bool SetLLMConfig(const std::string& host, int port, const std::string& model);
+
     virtual const APISettings& GetSettings() const;
     virtual void SetSettings(const APISettings& settings);
 

--- a/app/api/src/sonicpi_api.cpp
+++ b/app/api/src/sonicpi_api.cpp
@@ -1035,6 +1035,34 @@ bool SonicPiAPI::SaveAndRunBuffer(const std::string& name, const std::string& te
     return true;
 }
 
+bool SonicPiAPI::ProcessPrompt(const std::string& prompt)
+{
+    Message msg("/process-prompt");
+    msg.pushInt32(m_token);
+    msg.pushStr(prompt);
+    bool res = SendOSC(msg);
+    if (!res)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool SonicPiAPI::SetLLMConfig(const std::string& host, int port, const std::string& model)
+{
+    Message msg("/set-llm-config");
+    msg.pushInt32(m_token);
+    msg.pushStr(host);
+    msg.pushInt32(port);
+    msg.pushStr(model);
+    bool res = SendOSC(msg);
+    if (!res)
+    {
+        return false;
+    }
+    return true;
+}
+
 const APISettings& SonicPiAPI::GetSettings() const
 {
     return m_settings;

--- a/app/gui/qt/mainwindow.cpp
+++ b/app/gui/qt/mainwindow.cpp
@@ -458,6 +458,7 @@ void MainWindow::setupWindowStructure()
     connect(settingsWidget, SIGNAL(transparencyChanged(int)), this, SLOT(changeGUITransparency(int)));
 
     connect(settingsWidget, SIGNAL(checkUpdatesChanged()), this, SLOT(update_check_updates()));
+    connect(settingsWidget, SIGNAL(llmSettingsChanged(QString,int,QString)), this, SLOT(applyLLMConfig(QString,int,QString)));
     connect(settingsWidget, SIGNAL(forceCheckUpdates()), this, SLOT(check_for_updates_now()));
     connect(settingsWidget, SIGNAL(showContextChanged()), this, SLOT(changeShowContext()));
     connect(settingsWidget, SIGNAL(checkArgsChanged()), this, SLOT(changeAudioSafeMode()));
@@ -1514,6 +1515,7 @@ void MainWindow::honourPrefs()
     changeLogCues();
     changeClearOutputOnRun();
     changeAutoIndentOnRun();
+    applyLLMConfig(piSettings->ollama_host, piSettings->ollama_port, piSettings->ollama_model);
 }
 
 void MainWindow::setMessageBoxStyle()
@@ -1855,6 +1857,20 @@ void MainWindow::runCode()
     }
 
     statusBar()->showMessage(tr("Running Code..."), 1000);
+}
+
+void MainWindow::sendPrompt()
+{
+    QString text = llm_prompt->text();
+    if (!text.isEmpty())
+    {
+        m_spAPI->ProcessPrompt(text.toStdString());
+    }
+}
+
+void MainWindow::applyLLMConfig(QString host, int port, QString model)
+{
+    m_spAPI->SetLLMConfig(host.toStdString(), port, model.toStdString());
 }
 
 void MainWindow::zoomCurrentWorkspaceIn()
@@ -3454,6 +3470,11 @@ void MainWindow::createToolBar()
     toolBar->addAction(saveAsAct);
     toolBar->addAction(loadFileAct);
 
+    llm_prompt = new QLineEdit();
+    llm_prompt->setPlaceholderText(tr("LLM Prompt"));
+    toolBar->addWidget(llm_prompt);
+    connect(llm_prompt, SIGNAL(returnPressed()), this, SLOT(sendPrompt()));
+
     toolBar->addWidget(spacer);
 
     toolBar->addAction(textDecAct);
@@ -4280,6 +4301,10 @@ void MainWindow::readSettings()
     piSettings->hide_menubar_in_fullscreen = gui_settings->value("prefs/hide-menubar-in-fullscreen", false).toBool();
     QString styleName = gui_settings->value("prefs/theme", "").toString();
 
+    piSettings->ollama_host = gui_settings->value("prefs/llm-host", "127.0.0.1").toString();
+    piSettings->ollama_port = gui_settings->value("prefs/llm-port", 11434).toInt();
+    piSettings->ollama_model = gui_settings->value("prefs/llm-model", "sonic-pi").toString();
+
     piSettings->themeStyle = theme->themeNameToStyle(styleName);
     piSettings->show_autocompletion = gui_settings->value("prefs/show-autocompletion", true).toBool();
     piSettings->show_context = gui_settings->value("prefs/show-context", true).toBool();
@@ -4344,6 +4369,10 @@ void MainWindow::writeSettings()
     gui_settings->setValue("prefs/show-log", piSettings->show_log);
     gui_settings->setValue("prefs/show-context", piSettings->show_context);
     gui_settings->setValue("prefs/shortcut-mode", piSettings->shortcut_mode);
+
+    gui_settings->setValue("prefs/llm-host", piSettings->ollama_host);
+    gui_settings->setValue("prefs/llm-port", piSettings->ollama_port);
+    gui_settings->setValue("prefs/llm-model", piSettings->ollama_model);
 
     for (auto name : piSettings->scope_names)
     {

--- a/app/gui/qt/mainwindow.h
+++ b/app/gui/qt/mainwindow.h
@@ -151,6 +151,8 @@ private slots:
     QString asciiArtLogo();
     void printAsciiArtLogo();
     void runCode();
+    void sendPrompt();
+    void applyLLMConfig(QString host, int port, QString model);
     void update_check_updates();
     void mixerSettingsChanged();
     void check_for_updates_now();
@@ -414,6 +416,8 @@ private:
     bool is_recording;
     bool show_rec_icon_a;
     QTimer* rec_flash_timer;
+
+    QLineEdit* llm_prompt;
 
     QSplashScreen* splash;
 

--- a/app/gui/qt/model/settings.h
+++ b/app/gui/qt/model/settings.h
@@ -56,6 +56,11 @@ public:
     void setScopeState(QString name, bool s) { active_scopes[name] = s; }
     bool isScopeActive(QString name) { return active_scopes[name]; }
 
+    // LLM Settings
+    QString ollama_host = "127.0.0.1";
+    int ollama_port = 11434;
+    QString ollama_model = "sonic-pi";
+
     int shortcut_mode; // 1 = emacs, 2 = win, 3 = mac, 4 = user
 private:
     std::map<QString, bool> active_scopes;

--- a/app/gui/qt/widgets/settingswidget.cpp
+++ b/app/gui/qt/widgets/settingswidget.cpp
@@ -42,6 +42,9 @@ SettingsWidget::SettingsWidget(int tau_osc_cues_port, bool i18n, SonicPiSettings
     QGroupBox *ioTab = createIoPrefsTab();
     prefTabs->addTab(ioTab, tr("IO"));
 
+    QGroupBox *llmTab = createLLMPrefsTab();
+    prefTabs->addTab(llmTab, tr("LLM"));
+
     QGroupBox *editorTab = createEditorPrefsTab();
     prefTabs->addTab(editorTab, tr("Editor"));
 
@@ -273,6 +276,29 @@ QGroupBox* SettingsWidget::createIoPrefsTab() {
 
     ioTab->setLayout(io_tab_layout);
     return ioTab;
+}
+
+QGroupBox* SettingsWidget::createLLMPrefsTab() {
+    QGroupBox *llm_box = new QGroupBox();
+    llm_box->setToolTip(tr("Configure local LLM settings"));
+
+    QLabel *host_label = new QLabel(tr("Host"));
+    QLabel *port_label = new QLabel(tr("Port"));
+    QLabel *model_label = new QLabel(tr("Model"));
+
+    ollama_host_edit = new QLineEdit();
+    ollama_port_edit = new QLineEdit();
+    ollama_model_edit = new QLineEdit();
+
+    QGridLayout *layout = new QGridLayout;
+    layout->addWidget(host_label, 0, 0);
+    layout->addWidget(ollama_host_edit, 0, 1);
+    layout->addWidget(port_label, 1, 0);
+    layout->addWidget(ollama_port_edit, 1, 1);
+    layout->addWidget(model_label, 2, 0);
+    layout->addWidget(ollama_model_edit, 2, 1);
+    llm_box->setLayout(layout);
+    return llm_box;
 }
 
 /**
@@ -882,6 +908,10 @@ void SettingsWidget::updateSettings() {
     piSettings->midi_default_channel_str = channel_pat_str;
     piSettings->midi_enabled = midi_enable_check->isChecked();
 
+    piSettings->ollama_host = ollama_host_edit->text();
+    piSettings->ollama_port = ollama_port_edit->text().toInt();
+    piSettings->ollama_model = ollama_model_edit->text();
+
     piSettings->auto_indent_on_run = auto_indent_on_run->isChecked();
     piSettings->show_line_numbers = show_line_numbers->isChecked();
     piSettings->show_autocompletion = show_autocompletion->isChecked();
@@ -909,6 +939,8 @@ void SettingsWidget::updateSettings() {
     piSettings->hide_menubar_in_fullscreen = hide_menubar_in_fullscreen->isChecked();
 
     piSettings->check_updates = check_updates->isChecked();
+
+    emit llmSettingsChanged(piSettings->ollama_host, piSettings->ollama_port, piSettings->ollama_model);
 }
 
 void SettingsWidget::settingsChanged() {
@@ -969,6 +1001,9 @@ void SettingsWidget::settingsChanged() {
     check_updates->setChecked(piSettings->check_updates);
     show_autocompletion->setChecked(piSettings->show_autocompletion);
     show_context->setChecked(piSettings->show_context);
+    ollama_host_edit->setText(piSettings->ollama_host);
+    ollama_port_edit->setText(QString::number(piSettings->ollama_port));
+    ollama_model_edit->setText(piSettings->ollama_model);
     updateScopeKindVisibility();
 }
 
@@ -1044,6 +1079,10 @@ void SettingsWidget::connectAll() {
     connect(check_updates, SIGNAL(clicked()), this, SLOT(updateSettings()));
     connect(check_updates, SIGNAL(clicked()), this, SLOT(toggleCheckUpdates()));
     connect(visit_sonic_pi_net, SIGNAL(clicked()), this, SLOT(openSonicPiNet()));
+
+    connect(ollama_host_edit, SIGNAL(textChanged(QString)), this, SLOT(updateSettings()));
+    connect(ollama_port_edit, SIGNAL(textChanged(QString)), this, SLOT(updateSettings()));
+    connect(ollama_model_edit, SIGNAL(textChanged(QString)), this, SLOT(updateSettings()));
     connect(check_updates_now, SIGNAL(clicked()), this, SLOT(checkForUpdatesNow()));
 
     connect(show_autocompletion, SIGNAL(clicked()), this, SLOT(showAutoCompletion()));

--- a/app/gui/qt/widgets/settingswidget.h
+++ b/app/gui/qt/widgets/settingswidget.h
@@ -113,6 +113,7 @@ signals:
     void logSynthsChanged();
     void clearOutputOnRunChanged();
     void autoIndentOnRunChanged();
+    void llmSettingsChanged(QString host, int port, QString model);
 
 private:
     SonicPiSettings* piSettings;
@@ -171,6 +172,9 @@ private:
     QPushButton *visit_sonic_pi_net;
     QPushButton *check_studio_hash;
     QLineEdit   *user_token;
+    QLineEdit   *ollama_host_edit;
+    QLineEdit   *ollama_port_edit;
+    QLineEdit   *ollama_model_edit;
     QLabel *update_info;
     QLabel *midi_in_ports_label;
     QLabel *midi_out_ports_label;
@@ -187,6 +191,7 @@ private:
     // TODO
     QGroupBox* createAudioPrefsTab();
     QGroupBox* createIoPrefsTab();
+    QGroupBox* createLLMPrefsTab();
     QGroupBox* createEditorPrefsTab();
     QGroupBox* createVisualizationPrefsTab();
     QGroupBox* createUpdatePrefsTab();

--- a/app/server/ruby/bin/spider-server.rb
+++ b/app/server/ruby/bin/spider-server.rb
@@ -308,6 +308,30 @@ register_api = lambda do |server|
     end
   end
 
+  server.add_method("/process-prompt") do |args|
+    incoming_token = args[0]
+    if incoming_token == token
+      prompt = args[1].force_encoding("utf-8")
+      sp.__process_prompt(prompt)
+    else
+      STDOUT.puts "Invalid token: #{incoming_token} - ignoring /process-prompt API call"
+      STDOUT.flush
+    end
+  end
+
+  server.add_method("/set-llm-config") do |args|
+    incoming_token = args[0]
+    if incoming_token == token
+      host = args[1].force_encoding("utf-8")
+      port = args[2].to_i
+      model = args[3].force_encoding("utf-8")
+      sp.__set_llm_config(host, port, model)
+    else
+      STDOUT.puts "Invalid token: #{incoming_token} - ignoring /set-llm-config API call"
+      STDOUT.flush
+    end
+  end
+
   server.add_method("/save-buffer") do |args|
     incoming_token = args[0]
     if incoming_token == token

--- a/app/server/ruby/lib/sonicpi/runtime.rb
+++ b/app/server/ruby/lib/sonicpi/runtime.rb
@@ -27,9 +27,10 @@ require_relative "sthread"
 require_relative "version"
 require_relative "config/settings"
 require_relative "preparser"
-require_relative "event_history"
-require_relative "thread_id"
-require_relative "tau_api"
+    require_relative "event_history"
+    require_relative "thread_id"
+    require_relative "tau_api"
+    require 'json'
 
 #require_relative "oscevent"
 #require_relative "stream"
@@ -873,6 +874,37 @@ module SonicPi
 
     def __save_buffer(id, content)
       @save_queue << [id, content]
+    end
+
+    def __generate_code_from_prompt(prompt)
+      host = @settings.get(:ollama_host, '127.0.0.1')
+      port = @settings.get(:ollama_port, 11434)
+      model = @settings.get(:ollama_model, 'sonic-pi')
+      uri = URI.parse("http://#{host}:#{port}/api/generate")
+      req = Net::HTTP::Post.new(uri)
+      req['Content-Type'] = 'application/json'
+      req.body = MultiJson.dump({model: model, prompt: prompt, stream: false})
+      res = Net::HTTP.start(uri.hostname, uri.port) {|http| http.request(req)}
+      if res.is_a?(Net::HTTPSuccess)
+        data = MultiJson.load(res.body)
+        data['response'] || ''
+      else
+        ''
+      end
+    rescue StandardError => e
+      __info "LLM request failed: #{e.message}"
+      ''
+    end
+
+    def __process_prompt(prompt)
+      code = __generate_code_from_prompt(prompt)
+      __spider_eval(code, {workspace: 'prompt'}) unless code.empty?
+    end
+
+    def __set_llm_config(host, port, model)
+      @settings.set(:ollama_host, host)
+      @settings.set(:ollama_port, port)
+      @settings.set(:ollama_model, model)
     end
 
     def __disable_update_checker


### PR DESCRIPTION
## Summary
- add JSON dependency and new LLM helper methods to Ruby runtime
- expose new `/process-prompt` OSC endpoint in spider-server
- support prompt sending in SonicPiAPI
- add GUI text entry for LLM prompts and call `ProcessPrompt`
- allow configuring the Ollama instance via settings and expose `/set-llm-config`

## Testing
- `rake test`